### PR TITLE
chore: update action npm-publish version.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Lint
         run: npm run lint
       - name: Push to NPM registry
-        uses: JS-DevTools/npm-publish@v1.0.0
+        uses: JS-DevTools/npm-publish@v1.4.3
         with:
           token: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
Fixes the [issue](https://github.com/JS-DevTools/npm-publish/pull/19) with the [failed publish action](https://github.com/morganney/use-form-controlled/actions/runs/1742675001).