### PR TITLE
feat: add binary config, return required fields, parse untouched fields onSubmit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "use-form-controlled",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.2",
+      "name": "use-form-controlled",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.16.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "use-form-controlled",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
         "@babel/cli": "^7.16.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-form-controlled",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "React hook for managing form state, validation, and submission with controlled inputs.",
   "main": "dist",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "use-form-controlled",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "React hook for managing form state, validation, and submission with controlled inputs.",
   "main": "dist",
   "repository": {

--- a/src/index.js
+++ b/src/index.js
@@ -94,13 +94,10 @@ const useForm = (config = {}) => {
     [value]
   )
   const hasBlankRequired = useMemo(() => {
-    return (
-      isBlank ||
-      Object.keys(required)
-        .filter(field => required[field])
-        .some(field => value[field] === undefined)
-    )
-  }, [isBlank, required, value])
+    return Object.keys(required)
+      .filter(field => required[field])
+      .some(field => value[field] === undefined)
+  }, [required, value])
   const hasValidationError = useMemo(() => {
     return validationFields.some(field => error[field])
   }, [validationFields, error])


### PR DESCRIPTION
* Adds `binary` option to `register`.
* Returns `required` fields from hook.
* Correctly parses untouched fields that hold a value on form submission.